### PR TITLE
Investigate GraphQL as an alternative to Django REST Framework for the squash-api microservice

### DIFF
--- a/kubernetes/deployment-template.yaml
+++ b/kubernetes/deployment-template.yaml
@@ -34,6 +34,8 @@ spec:
           env:
           - name: SQUASH_API_URL
             value: {{ SQUASH_API_URL }}
+          - name: SQUASH_GRAPHQL_URL
+            value: {{ SQUASH_GRAPHQL_URL }}
           - name: SQUASH_BOKEH_URL
             value: {{ SQUASH_BOKEH_URL }}
           - name: ALLOWED_HOSTS

--- a/kubernetes/replace.sh
+++ b/kubernetes/replace.sh
@@ -36,6 +36,12 @@ if [ "$NAMESPACE" == "squash-prod" ]; then
     SQUASH_DASH_HOST="squash-dash.lsst.codes"
 fi
 
+SQUASH_GRAPHQL_URL="https://squash-graphql-${NAMESPACE}.lsst.codes"
+
+if [ "$NAMESPACE" == "squash-prod" ]; then
+    SQUASH_GRAPHQL_URL="https://squash-graphql.lsst.codes"
+fi
+
 SQUASH_API_URL="https://squash-api-${NAMESPACE}.lsst.codes"
 
 if [ "$NAMESPACE" == "squash-prod" ]; then
@@ -52,5 +58,6 @@ sed -e "
 s/{{ TAG }}/${TAG}/
 s/{{ SQUASH_DASH_HOST }}/${SQUASH_DASH_HOST}/
 s|{{ SQUASH_API_URL }}|\"${SQUASH_API_URL}\"|
+s|{{ SQUASH_GRAPHQL_URL }}|\"${SQUASH_GRAPHQL_URL}\"|
 s|{{ SQUASH_BOKEH_URL }}|\"${SQUASH_BOKEH_URL}\"|
 " $1 > $2

--- a/squash/dash/templates/base.html
+++ b/squash/dash/templates/base.html
@@ -56,8 +56,9 @@
             <!-- These menu items are always visible -->
             <ul class="nav navbar-nav navbar-right">
                 <li><a href="https://github.com/lsst-sqre/squash-deployment"><i class="fa fa-github fa-lg"></i><b> GitHub</b></a></li>
-                <li><a href="/api">API</a></li>
-                <li><a href="http://sqr-009.lsst.io/">Help</a></li>
+                <li><a href="/api">REST API</a></li>
+                <li><a href="/graphql">GraphQL</a></li>
+                <li><a href="/admin">Admin</a></li>
             </ul>
         </div>
     </div>

--- a/squash/dash/views.py
+++ b/squash/dash/views.py
@@ -9,7 +9,8 @@ from bokeh.embed import server_document
 
 # if not specified use the local url for development
 SQUASH_BOKEH_URL = os.environ.get('SQUASH_BOKEH_URL', 'http://localhost:5006')
-SQUASH_API_URL = os.environ.get('SQUASH_API_URL', 'http://localhost:8000/api')
+SQUASH_API_URL = os.environ.get('SQUASH_API_URL', None)
+SQUASH_GRAPHQL_URL = os.environ.get('SQUASH_GRAPHQL_URL', None)
 
 
 def is_server_up(url):
@@ -51,8 +52,7 @@ def embed_bokeh(request, bokeh_app):
     template = loader.get_template('dash/embed_bokeh.html')
 
     context = {'bokeh_script': bokeh_script,
-               'bokeh_app': bokeh_app,
-               'squash_api_url': SQUASH_API_URL}
+               'bokeh_app': bokeh_app}
 
     response = HttpResponse(template.render(context, request))
 
@@ -63,9 +63,18 @@ def api(request):
     """Render the API page"""
     return HttpResponseRedirect(SQUASH_API_URL)
 
+def graphql(request):
+    """Redirect to the GraphQL service"""
+    return HttpResponseRedirect(SQUASH_GRAPHQL_URL)
+
+def admin(request):
+    """Redirect to the django admin interface"""
+    admin_url = "{}/admin/".format(SQUASH_API_URL)
+    return HttpResponseRedirect(admin_url)
 
 def home(request):
-    """Render the home page"""
+    """Render the initial page, including statistics"""
+
 
     # TODO: get statistics from the SQUASH API
 

--- a/squash/squash/urls.py
+++ b/squash/squash/urls.py
@@ -19,6 +19,8 @@ from dash import views
 urlpatterns = [
     url(r'^$', views.home, name='home'),
     url(r'^api$', views.api, name='api'),
+    url(r'^graphql$', views.graphql, name='graphql'),
+    url(r'^admin$', views.admin, name='admin'),
     url(r'^dash/(?P<bokeh_app>\w+)/$', views.embed_bokeh,
         name='embed-bokeh'),
     url(r'^dash/monitor/(?P<bokeh_app>\w+)/$', views.embed_bokeh,


### PR DESCRIPTION
Changes required in the `squash-dash` microservice. 